### PR TITLE
replaced http request for changeRole store method

### DIFF
--- a/src/store/modules/users.ts
+++ b/src/store/modules/users.ts
@@ -160,7 +160,7 @@ export default {
      *
      * Author: cmc
      *
-     * Last Updated: January 27, 2022
+     * Last Updated: March 15, 2022
      * @param commit commit function
      * @param state state variables
      * @param {number} id user Id
@@ -182,11 +182,14 @@ export default {
       const user = state.users.find(el => el.id === id)
       if (user) {
         commit('changeUserRole', { user, role })
-        http.patch(
-          `accounts/${id}`,
-          { role: role }
+        http.post(
+          'accounts/change-role',
+          {
+            role: role,
+            userId: id
+          }
         )
-          // .then(() => console.log('user role changed!'))
+          .then(() => console.log('user role changed!'))
           .catch(err => console.error(err))
       }
     },


### PR DESCRIPTION
Fixed changeRole store method to use the correct http request to back end.

## What to test
- log on as admin
- create a dummy user in admin panel (or use existing user)
- change role in admin panel
- refresh
- see if change persisted