### PR TITLE
changed getLocale

### DIFF
--- a/src/components/header.vue
+++ b/src/components/header.vue
@@ -194,20 +194,18 @@ export default {
      *
      * Author: core
      *
-     * Last Updated: March 12, 2021
+     * Last Updated: June 8, 2022 by cmc
      */
     getLocale () {
-      const store = this.$store
-      /*
-      * get browser locale */
-      this.$store.dispatch('getBrowserLocale')
-        .then(lang => {
-          store.commit('setLang', lang)
-          document.documentElement.setAttribute('lang', lang)
-        })
-        .catch(() => {
-          store.commit('setLang', 'en')
-        })
+      const locales = navigator.languages
+      let lang
+      if (locales.length !== 0) {
+        lang = locales[0].substring(0, 2)
+      } else {
+        lang = navigator.language
+      }
+      this.$store.commit('setLang', lang)
+      document.documentElement.setAttribute('lang', lang)
     },
 
     /**

--- a/src/store/modules/auth.ts
+++ b/src/store/modules/auth.ts
@@ -246,6 +246,7 @@ export default {
 
     /**
      * function getBrowserLocale: return promise of 2-digit language code
+     * DEPRECATED AS OF JUNE 2022
      *
      * Author: cmc
      *


### PR DESCRIPTION
deprecated use of HTTP request to determine browser locale, use `navigator` object instead.

# What to test
- [ ] see if `setLang` vuex mutation has the correct payload (check your `navigator.languages` and `navigator.language` in browser console)