### PR TITLE
Fix for 'Show Solutions'. Correct format is now displayed.

### DIFF
--- a/src/plugins/laya-la-drag-drop/view.vue
+++ b/src/plugins/laya-la-drag-drop/view.vue
@@ -127,7 +127,7 @@ Dependencies:
         v-for="(item, index) in items"
         :key="index"
       >
-        {{ item.label }}: {{ courseSimple? categories[items[index].category].simple: categories[items[index].category].text }}
+        {{ item.label }}: {{ courseSimple? item.simple: item.text }}
       </div>
     </div>
   </div>

--- a/src/plugins/laya-la-drag-drop/view.vue
+++ b/src/plugins/laya-la-drag-drop/view.vue
@@ -127,7 +127,7 @@ Dependencies:
         v-for="(item, index) in items"
         :key="index"
       >
-        {{ item.label }}: {{ categories[items[index].category] }},
+        {{ item.label }}: {{ courseSimple? categories[items[index].category].simple: categories[items[index].category].text }}
       </div>
     </div>
   </div>

--- a/src/plugins/laya-la-drag-drop/view.vue
+++ b/src/plugins/laya-la-drag-drop/view.vue
@@ -127,7 +127,10 @@ Dependencies:
         v-for="(item, index) in items"
         :key="index"
       >
-        {{ item.label }}: {{ courseSimple? item.simple: item.text }}
+        {{ item.label }}: {{ courseSimple
+          ? categories[item.category].simple
+          : categories[item.category].text
+        }}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Drag&Drop should now display Solutions in correct format. Please check if

- [x] Format is now correct for Check Solution. Only Category and Answer should be displayed.
- [x] Check if Simple Language also works the same.

Note: we should consider renaming Categories and Items. Discuss in tomorrow's meeting.